### PR TITLE
Bump workflows version

### DIFF
--- a/.github/workflows/check-has-semver-label.yml
+++ b/.github/workflows/check-has-semver-label.yml
@@ -17,4 +17,4 @@ jobs:
   check-has-semver-label:
     permissions:
       pull-requests: write
-    uses: infrastructure-blocks/check-has-semver-label-workflow/.github/workflows/workflow.yml@v1
+    uses: infrastructure-blocks/check-has-semver-label-workflow/.github/workflows/workflow.yml@v2

--- a/.github/workflows/git-tag-semver-from-label.yml
+++ b/.github/workflows/git-tag-semver-from-label.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   git-tag-semver-from-label:
-    uses: infrastructure-blocks/git-tag-semver-from-label-workflow/.github/workflows/workflow.yml@v2
+    uses: infrastructure-blocks/git-tag-semver-from-label-workflow/.github/workflows/workflow.yml@v3
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/trigger-update-from-template.yml
+++ b/.github/workflows/trigger-update-from-template.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   trigger-update-from-template:
-    uses: infrastructure-blocks/trigger-update-from-template-workflow/.github/workflows/workflow.yml@v1
+    uses: infrastructure-blocks/trigger-update-from-template-workflow/.github/workflows/workflow.yml@v2
     secrets:
       github-pat: ${{ secrets.PAT }}

--- a/.github/workflows/update-from-template.yml
+++ b/.github/workflows/update-from-template.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   merge-template:
-    uses: infrastructure-blocks/merge-template-workflow/.github/workflows/workflow.yml@v1
+    uses: infrastructure-blocks/merge-template-workflow/.github/workflows/workflow.yml@v2
     with:
       labels: ${{ inputs.labels }}
     secrets:


### PR DESCRIPTION
- Closes infrastructure-blocks/docker-compose-metadata-workflow#12
- Closes infrastructure-blocks/npm-publish-from-label-workflow#18
- Closes infrastructure-blocks/check-has-semver-label-workflow#20
- Closes infrastructure-blocks/aws-ecr-docker-tag-workflow#12
- Closes infrastructure-blocks/trigger-update-from-template-workflow#23
- Closes infrastructure-blocks/merge-template-workflow#28
- Closes infrastructure-blocks/git-tag-semver-workflow#12
- Closes infrastructure-blocks/git-tag-semver-from-label-workflow#22
