### PR TITLE
Fix release workflows dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,12 @@ jobs:
       pull-requests: write
     uses: infrastructure-blocks/check-has-semver-label-workflow/.github/workflows/workflow.yml@v2
   git-tag-from-semver-increment:
-    uses: infrastructure-blocks/git-tag-from-semver-increment-workflow/.github/workflows/workflow.yml@v1
+    needs:
+      - check-has-semver-label
     permissions:
       contents: write
       pull-requests: write
+    uses: infrastructure-blocks/git-tag-from-semver-increment-workflow/.github/workflows/workflow.yml@v1
     with:
       semver-increment: ${{ needs.check-has-semver-label.outputs.matched-label }}
       skip: ${{ needs.check-has-semver-label.outputs.matched-label == 'no version' }}


### PR DESCRIPTION
- Make git-tag-from-semver-increment dependent on check-has-semver-label as
it uses the output of the former.
